### PR TITLE
Fix compilation.

### DIFF
--- a/kobuki_ftdi/CMakeLists.txt
+++ b/kobuki_ftdi/CMakeLists.txt
@@ -4,15 +4,14 @@ find_package(catkin REQUIRED COMPONENTS ecl_command_line)
 
 # pkg-config packages
 find_package(PkgConfig)
-pkg_search_module(REQUIRED libusb-dev)
-pkg_search_module(REQUIRED libftdi-dev)
-pkg_search_module(REQUIRED ftdi-eeprom)
+pkg_search_module(REQUIRED libusb)
+pkg_search_module(REQUIRED libftdi)
 
 catkin_package(
    INCLUDE_DIRS include
    LIBRARIES kobuki_ros kobuki_nodelet
    CATKIN_DEPENDS ecl_command_line
-   DEPENDS libusb-dev libftdi-dev ftdi-eeprom
+   DEPENDS libusb libftdi
 )
 
 include_directories(include ${catkin_INCLUDE_DIRS})


### PR DESCRIPTION
- fix the names of the pkg-config libraries of libusb and libftdi. I checked
  on Ubuntu and OS X.
- ftdi-eeprom is not a library and has no pkg-config file.
