### PR TITLE
Update cliff.hpp

### DIFF
--- a/kobuki_driver/include/kobuki_driver/packets/cliff.hpp
+++ b/kobuki_driver/include/kobuki_driver/packets/cliff.hpp
@@ -44,7 +44,7 @@ public:
 
   bool serialise(ecl::PushAndPop<unsigned char> & byteStream)
   {
-    buildBytes(Header::Cliff, byteStream);
+    buildBytes((unsigned char)Header::Cliff, byteStream);
     buildBytes(length, byteStream);
     buildBytes(data.bottom[0], byteStream);
     buildBytes(data.bottom[1], byteStream);


### PR DESCRIPTION
sizeof (enum Header::Cliff) is sizeof(int) , not sizeof(unsigned char);

Size of data field is byte;
