### PR TITLE
Added state where dock_detector = 0

### DIFF
--- a/kobuki_dock_drive/src/dock_drive_states.cpp
+++ b/kobuki_dock_drive/src/dock_drive_states.cpp
@@ -181,6 +181,12 @@ namespace kobuki {
         next_wz = 0.33;
       }
     }
+    else // robot can't locate the dock
+    {
+      next_state = RobotDockingState::LOST;
+      next_vx = 0.0;
+      next_wz = 0.0;
+    }
 
     nstate = next_state;
     nvx = next_vx;


### PR DESCRIPTION
When the kobuki is attempting to auto dock but there is not an actual docking station, the instance will crash as is only verifying if the dock_detector value is grater than or less than 0 but not when is 0.