### PR TITLE
 Make kobuki_core build for ROS2 (and Windows 10)

### DIFF
--- a/kobuki_core/CMakeLists.txt
+++ b/kobuki_core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(kobuki_core)
-find_package(catkin REQUIRED)
-catkin_metapackage()
+find_package(ament_cmake REQUIRED)
+#catkin_metapackage()

--- a/kobuki_core/package.xml
+++ b/kobuki_core/package.xml
@@ -1,4 +1,5 @@
-<package>
+<?xml version="1.0"?>
+<package format="2">
   <name>kobuki_core</name>
   <version>0.7.8</version>
   <description>
@@ -14,13 +15,14 @@
   <url type="repository">https://github.com/yujinrobot/kobuki_core</url>
   <url type="website">http://ros.org/wiki/kobuki_core</url>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <run_depend>kobuki_dock_drive</run_depend> 
-  <run_depend>kobuki_driver</run_depend>
-  <run_depend>kobuki_ftdi</run_depend>
+  <exec_depend>kobuki_dock_drive</exec_depend> 
+  <exec_depend>kobuki_driver</exec_depend>
+  <exec_depend>kobuki_ftdi</exec_depend>
 
   <export>
-    <metapackage/>
+    <build_type>ament_cmake</build_type>
+	<metapackage/>
   </export>
 </package>

--- a/kobuki_dock_drive/CMakeLists.txt
+++ b/kobuki_dock_drive/CMakeLists.txt
@@ -2,53 +2,50 @@
 # CMake
 ##############################################################################
 
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(kobuki_dock_drive)
 
 ##############################################################################
 # Find Packages
 ##############################################################################
 
-find_package(catkin
-    REQUIRED
-    COMPONENTS
-        ecl_build
-        ecl_threads
-        ecl_geometry
-        ecl_linear_algebra
-)
-
-##############################################################################
-# Exports
-##############################################################################
-
-catkin_package(
-   INCLUDE_DIRS include
-   LIBRARIES kobuki_dock_drive
-   CATKIN_DEPENDS ecl_threads ecl_geometry ecl_linear_algebra
-)
+find_package(ament_cmake REQUIRED)
+find_package(ecl_build REQUIRED)
+find_package(ecl_threads REQUIRED)
+find_package(ecl_geometry REQUIRED)
+find_package(ecl_linear_algebra REQUIRED)
 
 ##############################################################################
 # Project Configuration
 ##############################################################################
 
 ecl_enable_cxx11_compiler()
-include_directories(include ${catkin_INCLUDE_DIRS})
+include_directories(include
+  ${ecl_build_INCLUDE_DIRS}
+  ${ecl_threads_INCLUDE_DIRS}
+  ${ecl_geometry_INCLUDE_DIRS}
+  ${ecl_linear_algebra_INCLUDE_DIRS}
+  )
 
 ##############################################################################
 # Sources
 ##############################################################################
 
 add_library(kobuki_dock_drive src/dock_drive.cpp src/dock_drive_states.cpp src/dock_drive_debug.cpp)
-target_link_libraries(kobuki_dock_drive ${catkin_LIBRARIES})
+target_link_libraries(kobuki_dock_drive
+  ${ecl_build_LIBRARIES}
+  ${ecl_threads_LIBRARIES}
+  ${ecl_geometry_LIBRARIES}
+  ${ecl_linear_algebra_LIBRARIES}
+)
 
 ##############################################################################
 # Installs
 ##############################################################################
 
 install(TARGETS kobuki_dock_drive
-        DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        DESTINATION lib
 )
 install(DIRECTORY include/${PROJECT_NAME}/
-        DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+        DESTINATION include
 )

--- a/kobuki_dock_drive/package.xml
+++ b/kobuki_dock_drive/package.xml
@@ -1,4 +1,5 @@
-<package>
+<?xml version="1.0"?>
+<package format="2">
   <name>kobuki_dock_drive</name>
   <version>0.7.8</version>
   <description>
@@ -12,12 +13,16 @@
   <url type="repository">https://github.com/yujinrobot/kobuki_core</url>
   <url type="website">http://ros.org/wiki/kobuki_dock_drive</url>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
   <build_depend>ecl_build</build_depend>
   <build_depend>ecl_threads</build_depend>
   <build_depend>ecl_geometry</build_depend>
   <build_depend>ecl_linear_algebra</build_depend>
-  <run_depend>ecl_threads</run_depend>
-  <run_depend>ecl_geometry</run_depend>
-  <run_depend>ecl_linear_algebra</run_depend>
+  <exec_depend>ecl_threads</exec_depend>
+  <exec_depend>ecl_geometry</exec_depend>
+  <exec_depend>ecl_linear_algebra</exec_depend>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/kobuki_driver/CMakeLists.txt
+++ b/kobuki_driver/CMakeLists.txt
@@ -2,49 +2,38 @@
 # Cmake
 ##############################################################################
 
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(kobuki_driver)
 
 ##############################################################################
 # Catkin
 ##############################################################################
 
-find_package(catkin
-    REQUIRED
-    COMPONENTS
-        ecl_build
-        ecl_mobile_robot
-        ecl_converters
-        ecl_devices
-        ecl_geometry
-        ecl_sigslots
-        ecl_time
-        ecl_command_line
-)
-
-##############################################################################
-# Exports
-##############################################################################
-
-catkin_package(
-    INCLUDE_DIRS include
-    LIBRARIES kobuki
-    CATKIN_DEPENDS
-        ecl_command_line
-        ecl_converters
-        ecl_devices
-        ecl_geometry
-        ecl_mobile_robot
-        ecl_sigslots
-        ecl_time
-)
+find_package(ament_cmake REQUIRED)
+find_package(ecl_build REQUIRED)
+find_package(ecl_mobile_robot REQUIRED)
+find_package(ecl_converters REQUIRED)
+find_package(ecl_devices REQUIRED)
+find_package(ecl_geometry REQUIRED)
+find_package(ecl_sigslots REQUIRED)
+find_package(ecl_time REQUIRED)
+find_package(ecl_command_line REQUIRED)
 
 ##############################################################################
 # Project Configuration
 ##############################################################################
 
 ecl_enable_cxx11_compiler()
-include_directories(include ${catkin_INCLUDE_DIRS})
+include_directories(include 
+  ${ecl_build_INCLUDE_DIRS}
+  ${ecl_mobile_robot_INCLUDE_DIRS}
+  ${ecl_converters_INCLUDE_DIRS}
+  ${ecl_devices_INCLUDE_DIRS}
+  ${ecl_geometry_INCLUDE_DIRS}
+  ${ecl_sigslots_INCLUDE_DIRS}
+  ${ecl_time_INCLUDE_DIRS}
+  ${ecl_command_line_INCLUDE_DIRS}
+  )
 
 ##############################################################################
 # Sources
@@ -53,5 +42,14 @@ include_directories(include ${catkin_INCLUDE_DIRS})
 add_subdirectory(src)
 
 install(DIRECTORY include/${PROJECT_NAME}/
-        DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+        DESTINATION include/kobuki_driver
 )
+
+
+ament_export_include_directories(include/kobuki_driver)
+ament_export_dependencies(ecl_time)
+ament_export_dependencies(ecl_devices)
+ament_export_dependencies(ecl_geometry)
+ament_export_dependencies(ecl_mobile_robot)
+ament_export_libraries(kobuki)
+ament_package()

--- a/kobuki_driver/CMakeLists.txt
+++ b/kobuki_driver/CMakeLists.txt
@@ -10,6 +10,9 @@ project(kobuki_driver)
 ##############################################################################
 
 find_package(ament_cmake REQUIRED)
+find_package(rcl REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rcutils REQUIRED)
 find_package(ecl_build REQUIRED)
 find_package(ecl_mobile_robot REQUIRED)
 find_package(ecl_converters REQUIRED)
@@ -18,6 +21,7 @@ find_package(ecl_geometry REQUIRED)
 find_package(ecl_sigslots REQUIRED)
 find_package(ecl_time REQUIRED)
 find_package(ecl_command_line REQUIRED)
+find_package(kobuki_msgs REQUIRED)
 
 ##############################################################################
 # Project Configuration
@@ -25,6 +29,9 @@ find_package(ecl_command_line REQUIRED)
 
 ecl_enable_cxx11_compiler()
 include_directories(include 
+  ${rcl_INCLUDE_DIRS}
+  ${rclcpp_INCLUDE_DIRS}
+  ${rcutils_INCLUDE_DIRS}
   ${ecl_build_INCLUDE_DIRS}
   ${ecl_mobile_robot_INCLUDE_DIRS}
   ${ecl_converters_INCLUDE_DIRS}
@@ -33,6 +40,7 @@ include_directories(include
   ${ecl_sigslots_INCLUDE_DIRS}
   ${ecl_time_INCLUDE_DIRS}
   ${ecl_command_line_INCLUDE_DIRS}
+  ${kobuki_msgs_INCLUDE_DIRS}
   )
 
 ##############################################################################
@@ -47,9 +55,13 @@ install(DIRECTORY include/${PROJECT_NAME}/
 
 
 ament_export_include_directories(include/kobuki_driver)
+ament_export_dependencies(rcl)
+ament_export_dependencies(rclcpp)
+ament_export_dependencies(rcutils)
 ament_export_dependencies(ecl_time)
 ament_export_dependencies(ecl_devices)
 ament_export_dependencies(ecl_geometry)
 ament_export_dependencies(ecl_mobile_robot)
+ament_export_dependencies(kobuki_msgs)
 ament_export_libraries(kobuki)
 ament_package()

--- a/kobuki_driver/include/kobuki_driver/event_manager.hpp
+++ b/kobuki_driver/include/kobuki_driver/event_manager.hpp
@@ -19,7 +19,16 @@
 
 #include <stdint.h>
 #include <vector>
-#include <ecl/sigslots.hpp>
+
+#include "rclcpp/rclcpp.hpp"
+#include <kobuki_msgs/msg/bumper_event.hpp>
+#include <kobuki_msgs/msg/cliff_event.hpp>
+#include <kobuki_msgs/msg/led.hpp>
+#include <kobuki_msgs/msg/wheel_drop_event.hpp>
+#include <kobuki_msgs/msg/button_event.hpp>
+#include <kobuki_msgs/msg/power_system_event.hpp>
+#include <kobuki_msgs/msg/digital_input_event.hpp>
+#include <kobuki_msgs/msg/robot_state_event.hpp>
 
 #include "packets/core_sensors.hpp"
 #include "macros.hpp"
@@ -132,13 +141,13 @@ private:
   uint16_t          last_digital_input;
   RobotEvent::State last_robot_state;
 
-  ecl::Signal<const ButtonEvent&> sig_button_event;
-  ecl::Signal<const BumperEvent&> sig_bumper_event;
-  ecl::Signal<const CliffEvent&>  sig_cliff_event;
-  ecl::Signal<const WheelEvent&>  sig_wheel_event;
-  ecl::Signal<const PowerEvent&>  sig_power_event;
-  ecl::Signal<const InputEvent&>  sig_input_event;
-  ecl::Signal<const RobotEvent&>  sig_robot_event;
+  std::shared_ptr<rclcpp::Publisher<kobuki_msgs::msg::BumperEvent>> bumper_pub;
+  std::shared_ptr<rclcpp::Publisher<kobuki_msgs::msg::CliffEvent>> cliff_pub;
+  std::shared_ptr<rclcpp::Publisher<kobuki_msgs::msg::WheelDropEvent>> drop_pub;
+  std::shared_ptr<rclcpp::Publisher<kobuki_msgs::msg::ButtonEvent>> button_pub;
+  std::shared_ptr<rclcpp::Publisher<kobuki_msgs::msg::PowerSystemEvent>> power_pub;
+  std::shared_ptr<rclcpp::Publisher<kobuki_msgs::msg::DigitalInputEvent>> input_pub;
+  std::shared_ptr<rclcpp::Publisher<kobuki_msgs::msg::RobotStateEvent>> robot_pub;
 };
 
 

--- a/kobuki_driver/include/kobuki_driver/packets/firmware.hpp
+++ b/kobuki_driver/include/kobuki_driver/packets/firmware.hpp
@@ -69,7 +69,7 @@ public:
     buildVariable(header_id, byteStream);
     buildVariable(length_packed, byteStream);
     if( header_id != Header::Firmware ) return false;
-    if( length_packed != 2 and length_packed != 4) return false;
+    if( length_packed != 2 && length_packed != 4) return false;
 
     // TODO First 3 firmware versions coded version number on 2 bytes, so we need convert manually to our new
     // 4 bytes system; remove this horrible, dirty hack as soon as we upgrade the firmware to 1.1.2 or 1.2.0

--- a/kobuki_driver/include/kobuki_driver/packets/hardware.hpp
+++ b/kobuki_driver/include/kobuki_driver/packets/hardware.hpp
@@ -61,7 +61,7 @@ public:
     buildVariable(header_id, byteStream);
     buildVariable(length_packed, byteStream);
     if( header_id != Header::Hardware ) return false;
-    if( length_packed != 2 and length_packed != 4) return false;
+    if( length_packed != 2 && length_packed != 4) return false;
 
     // TODO First 3 firmware versions coded version number on 2 bytes, so we need convert manually to our new
     // 4 bytes system; remove this horrible, dirty hack as soon as we upgrade the firmware to 1.1.2 or 1.2.0

--- a/kobuki_driver/package.xml
+++ b/kobuki_driver/package.xml
@@ -1,4 +1,5 @@
-<package>
+<?xml version="1.0"?>
+<package format="2">
   <name>kobuki_driver</name>
   <version>0.7.8</version>
   <description>
@@ -14,7 +15,7 @@
   <url type="repository">https://github.com/yujinrobot/kobuki_core</url>
   <url type="website">http://ros.org/wiki/kobuki_driver</url>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>ecl_build</build_depend>
   <build_depend>ecl_mobile_robot</build_depend>
@@ -25,11 +26,14 @@
   <build_depend>ecl_time</build_depend>
   <build_depend>ecl_command_line</build_depend>
 
-  <run_depend>ecl_mobile_robot</run_depend>
-  <run_depend>ecl_converters</run_depend>
-  <run_depend>ecl_devices</run_depend>
-  <run_depend>ecl_geometry</run_depend>
-  <run_depend>ecl_sigslots</run_depend>
-  <run_depend>ecl_time</run_depend>
-  <run_depend>ecl_command_line</run_depend>
+  <exec_depend>ecl_mobile_robot</exec_depend>
+  <exec_depend>ecl_converters</exec_depend>
+  <exec_depend>ecl_devices</exec_depend>
+  <exec_depend>ecl_geometry</exec_depend>
+  <exec_depend>ecl_sigslots</exec_depend>
+  <exec_depend>ecl_time</exec_depend>
+  <exec_depend>ecl_command_line</exec_depend>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/kobuki_driver/package.xml
+++ b/kobuki_driver/package.xml
@@ -17,6 +17,11 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>rcl</depend>
+  <depend>rclcpp</depend>
+  <depend>rcutils</depend>
+  <depend>kobuki_msgs</depend>
+
   <build_depend>ecl_build</build_depend>
   <build_depend>ecl_mobile_robot</build_depend>
   <build_depend>ecl_converters</build_depend>

--- a/kobuki_driver/src/driver/CMakeLists.txt
+++ b/kobuki_driver/src/driver/CMakeLists.txt
@@ -16,9 +16,18 @@ configure_file(version_info.cpp.in ${VERSION_FILE} @ONLY)
 ##############################################################################
 
 add_library(kobuki ${SOURCES} ${VERSION_FILE})
-target_link_libraries(kobuki ${catkin_LIBRARIES})
+target_link_libraries(kobuki 
+  ${ecl_build_LIBRARIES}
+  ${ecl_mobile_robot_LIBRARIES}
+  ${ecl_converters_LIBRARIES}
+  ${ecl_devices_LIBRARIES}
+  ${ecl_geometry_LIBRARIES}
+  ${ecl_sigslots_LIBRARIES}
+  ${ecl_time_LIBRARIES}
+  ${ecl_command_line_LIBRARIES}
+  )
 
 install(TARGETS kobuki
-        DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        DESTINATION lib
 )
 

--- a/kobuki_driver/src/driver/CMakeLists.txt
+++ b/kobuki_driver/src/driver/CMakeLists.txt
@@ -17,6 +17,9 @@ configure_file(version_info.cpp.in ${VERSION_FILE} @ONLY)
 
 add_library(kobuki ${SOURCES} ${VERSION_FILE})
 target_link_libraries(kobuki 
+  ${rcl_LIBRARIES}
+  ${rclcpp_LIBRARIES}
+  ${rcutils_LIBRARIES}
   ${ecl_build_LIBRARIES}
   ${ecl_mobile_robot_LIBRARIES}
   ${ecl_converters_LIBRARIES}
@@ -25,6 +28,7 @@ target_link_libraries(kobuki
   ${ecl_sigslots_LIBRARIES}
   ${ecl_time_LIBRARIES}
   ${ecl_command_line_LIBRARIES}
+  ${kobuki_msgs_LIBRARIES}
   )
 
 install(TARGETS kobuki

--- a/kobuki_driver/src/driver/kobuki.cpp
+++ b/kobuki_driver/src/driver/kobuki.cpp
@@ -48,6 +48,10 @@ bool PacketFinder::checkSum()
  ** Implementation [Initialisation]
  *****************************************************************************/
 
+#ifdef _MSC_VER
+#include <limits>
+#endif
+
 Kobuki::Kobuki() :
     shutdown_requested(false)
     , is_enabled(false)
@@ -55,7 +59,11 @@ Kobuki::Kobuki() :
     , is_alive(false)
     , version_info_reminder(0)
     , controller_info_reminder(0)
-    , heading_offset(0.0/0.0)
+#ifdef _MSC_VER
+    , heading_offset(std::numeric_limits<double>::quiet_NaN())
+#else
+    , heading_offset(0.0 / 0.0)
+#endif
     , velocity_commands_debug(4, 0)
 {
 }

--- a/kobuki_driver/src/test/CMakeLists.txt
+++ b/kobuki_driver/src/test/CMakeLists.txt
@@ -15,5 +15,5 @@ add_executable(demo_kobuki_simple_loop simple_loop.cpp)
 target_link_libraries(demo_kobuki_simple_loop kobuki)
 
 install(TARGETS kobuki_velocity_commands demo_kobuki_initialisation demo_kobuki_sigslots demo_kobuki_simple_loop
-        DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+        DESTINATION bin
 )

--- a/kobuki_driver/src/test/CMakeLists.txt
+++ b/kobuki_driver/src/test/CMakeLists.txt
@@ -3,16 +3,68 @@
 ###############################################################################
 
 add_executable(kobuki_velocity_commands velocity_commands.cpp)
-target_link_libraries(kobuki_velocity_commands kobuki)
+target_link_libraries(kobuki_velocity_commands kobuki 
+  ${rcl_LIBRARIES}
+  ${rclcpp_LIBRARIES}
+  ${rcutils_LIBRARIES}
+  ${ecl_build_LIBRARIES}
+  ${ecl_mobile_robot_LIBRARIES}
+  ${ecl_converters_LIBRARIES}
+  ${ecl_devices_LIBRARIES}
+  ${ecl_geometry_LIBRARIES}
+  ${ecl_sigslots_LIBRARIES}
+  ${ecl_time_LIBRARIES}
+  ${ecl_command_line_LIBRARIES}
+  ${kobuki_msgs_LIBRARIES}
+  )
 
 add_executable(demo_kobuki_initialisation initialisation.cpp)
-target_link_libraries(demo_kobuki_initialisation kobuki)
+target_link_libraries(demo_kobuki_initialisation kobuki 
+  ${rcl_LIBRARIES}
+  ${rclcpp_LIBRARIES}
+  ${rcutils_LIBRARIES}
+  ${ecl_build_LIBRARIES}
+  ${ecl_mobile_robot_LIBRARIES}
+  ${ecl_converters_LIBRARIES}
+  ${ecl_devices_LIBRARIES}
+  ${ecl_geometry_LIBRARIES}
+  ${ecl_sigslots_LIBRARIES}
+  ${ecl_time_LIBRARIES}
+  ${ecl_command_line_LIBRARIES}
+  ${kobuki_msgs_LIBRARIES}
+  )
 
 add_executable(demo_kobuki_sigslots sigslots.cpp)
-target_link_libraries(demo_kobuki_sigslots kobuki)
+target_link_libraries(demo_kobuki_sigslots kobuki 
+  ${rcl_LIBRARIES}
+  ${rclcpp_LIBRARIES}
+  ${rcutils_LIBRARIES}
+  ${ecl_build_LIBRARIES}
+  ${ecl_mobile_robot_LIBRARIES}
+  ${ecl_converters_LIBRARIES}
+  ${ecl_devices_LIBRARIES}
+  ${ecl_geometry_LIBRARIES}
+  ${ecl_sigslots_LIBRARIES}
+  ${ecl_time_LIBRARIES}
+  ${ecl_command_line_LIBRARIES}
+  ${kobuki_msgs_LIBRARIES}
+  )
 
 add_executable(demo_kobuki_simple_loop simple_loop.cpp)
-target_link_libraries(demo_kobuki_simple_loop kobuki)
+target_link_libraries(demo_kobuki_simple_loop kobuki 
+  ${rcl_LIBRARIES}
+  ${rclcpp_LIBRARIES}
+  ${rcutils_LIBRARIES}
+  ${ecl_build_LIBRARIES}
+  ${ecl_mobile_robot_LIBRARIES}
+  ${ecl_converters_LIBRARIES}
+  ${ecl_devices_LIBRARIES}
+  ${ecl_geometry_LIBRARIES}
+  ${ecl_sigslots_LIBRARIES}
+  ${ecl_time_LIBRARIES}
+  ${ecl_command_line_LIBRARIES}
+  ${kobuki_msgs_LIBRARIES}
+ )
 
 install(TARGETS kobuki_velocity_commands demo_kobuki_initialisation demo_kobuki_sigslots demo_kobuki_simple_loop
         DESTINATION bin

--- a/kobuki_driver/src/test/velocity_commands.cpp
+++ b/kobuki_driver/src/test/velocity_commands.cpp
@@ -14,6 +14,9 @@
 #include <iostream>
 #include <cstdio>
 #include <cmath>
+#ifdef _MSC_VER
+#include <algorithm>
+#endif // _MSC_VER
 
 double bias, radius, speed;
 

--- a/kobuki_driver/src/tools/CMakeLists.txt
+++ b/kobuki_driver/src/tools/CMakeLists.txt
@@ -3,14 +3,40 @@
 ###############################################################################
 
 add_executable(version_info version_info.cpp)
-target_link_libraries(version_info kobuki)
+target_link_libraries(version_info kobuki 
+  ${rcl_LIBRARIES}
+  ${rclcpp_LIBRARIES}
+  ${rcutils_LIBRARIES}
+  ${ecl_build_LIBRARIES}
+  ${ecl_mobile_robot_LIBRARIES}
+  ${ecl_converters_LIBRARIES}
+  ${ecl_devices_LIBRARIES}
+  ${ecl_geometry_LIBRARIES}
+  ${ecl_sigslots_LIBRARIES}
+  ${ecl_time_LIBRARIES}
+  ${ecl_command_line_LIBRARIES}
+  ${kobuki_msgs_LIBRARIES}
+  )
 install(TARGETS version_info
         DESTINATION bin
 )
 
 if (NOT ${MSVC})
 add_executable(simple_keyop simple_keyop.cpp)
-target_link_libraries(simple_keyop kobuki)
+target_link_libraries(simple_keyop kobuki 
+  ${rcl_LIBRARIES}
+  ${rclcpp_LIBRARIES}
+  ${rcutils_LIBRARIES}
+  ${ecl_build_LIBRARIES}
+  ${ecl_mobile_robot_LIBRARIES}
+  ${ecl_converters_LIBRARIES}
+  ${ecl_devices_LIBRARIES}
+  ${ecl_geometry_LIBRARIES}
+  ${ecl_sigslots_LIBRARIES}
+  ${ecl_time_LIBRARIES}
+  ${ecl_command_line_LIBRARIES}
+  ${kobuki_msgs_LIBRARIES}
+  )
 install(TARGETS simple_keyop
         DESTINATION bin
 )

--- a/kobuki_driver/src/tools/CMakeLists.txt
+++ b/kobuki_driver/src/tools/CMakeLists.txt
@@ -4,10 +4,14 @@
 
 add_executable(version_info version_info.cpp)
 target_link_libraries(version_info kobuki)
+install(TARGETS version_info
+        DESTINATION bin
+)
 
+if (NOT ${MSVC})
 add_executable(simple_keyop simple_keyop.cpp)
 target_link_libraries(simple_keyop kobuki)
-
-install(TARGETS version_info simple_keyop
-        DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+install(TARGETS simple_keyop
+        DESTINATION bin
 )
+endif()

--- a/kobuki_ftdi/CMakeLists.txt
+++ b/kobuki_ftdi/CMakeLists.txt
@@ -1,35 +1,35 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(kobuki_ftdi)
-find_package(catkin REQUIRED COMPONENTS ecl_command_line)
+find_package(ament_cmake REQUIRED)
+find_package(ecl_command_line REQUIRED)
 
 # pkg-config packages
 find_package(PkgConfig)
 pkg_search_module(libusb REQUIRED libusb)
 pkg_search_module(libftdi REQUIRED libftdi)
 
-catkin_package(
-   INCLUDE_DIRS include
-   CATKIN_DEPENDS ecl_command_line
-   DEPENDS libusb libftdi
-)
-
-include_directories(include ${catkin_INCLUDE_DIRS})
+include_directories(include 
+  ${ecl_command_line_INCLUDE_DIRS}
+  ${PkgConfig_INCLUDE_DIRS}
+  ${libusb_INCLUDE_DIRS}
+  ${libftdi_INCLUDE_DIRS}
+  )
 
 add_subdirectory(src)
 
 install(DIRECTORY bluetooth
-        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+        DESTINATION share
 )
 install(DIRECTORY eeproms
-        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+        DESTINATION share
 )
 install(PROGRAMS scripts/turtlebot_config
                  scripts/create_udev_rules
-        DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+        DESTINATION bin
 )
 
 install(FILES 57-kobuki.rules
-        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+        DESTINATION share
 )
 
 # This has issues....hydro doing th same thing will result in 

--- a/kobuki_ftdi/package.xml
+++ b/kobuki_ftdi/package.xml
@@ -1,4 +1,5 @@
-<package>
+<?xml version="1.0"?>
+<package format="2">
   <name>kobuki_ftdi</name>
   <version>0.7.8</version>
   <description>
@@ -14,7 +15,7 @@
   <url type="repository">https://github.com/yujinrobot/kobuki_core</url>
   <url type="website">http://ros.org/wiki/kobuki_ftdi</url>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>ecl_command_line</build_depend>
   <build_depend>libusb-dev</build_depend>
@@ -22,9 +23,12 @@
   <build_depend>pkg-config</build_depend>
   <build_depend>ftdi-eeprom</build_depend>
 
-  <run_depend>ecl_command_line</run_depend>
+  <exec_depend>ecl_command_line</exec_depend>
 
-  <run_depend>libusb-dev</run_depend>
-  <run_depend>libftdi-dev</run_depend>
-  <run_depend>ftdi-eeprom</run_depend>
+  <exec_depend>libusb-dev</exec_depend>
+  <exec_depend>libftdi-dev</exec_depend>
+  <exec_depend>ftdi-eeprom</exec_depend>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/kobuki_ftdi/src/CMakeLists.txt
+++ b/kobuki_ftdi/src/CMakeLists.txt
@@ -34,5 +34,5 @@ target_link_libraries(unflasher usb ftdi)
 
 install(TARGETS ftdi_scan ftdi_kobuki ftdi_read_eeprom ftdi_write_eeprom find_devices
                 get_serial_number flasher reset_device overwrite_serial_number unflasher
-        DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+        DESTINATION bin
 )


### PR DESCRIPTION
Should go to a ROS2 branch.

This is a part of an effort to port Kobuki and Turtlebot2 to ROS2 and Windows 10.
