### PR TITLE
backport of "Dashing update" to melodic to fix compiler warnings and errors

### DIFF
--- a/kobuki_dock_drive/src/dock_drive.cpp
+++ b/kobuki_dock_drive/src/dock_drive.cpp
@@ -56,16 +56,17 @@ namespace kobuki {
 ** Implementation
 *****************************************************************************/
 DockDrive::DockDrive() :
-  is_enabled(false), can_run(false)
+  is_enabled(false)
+  , can_run(false)
   , state(RobotDockingState::IDLE), state_str("IDLE")
   , vx(0.0), wz(0.0)
+  , signal_window(20)
   , bump_remainder(0)
   , dock_stabilizer(0)
   , dock_detector(0)
   , rotated(0.0)
   , min_abs_v(0.01)
   , min_abs_w(0.1)
-  , signal_window(20)
   , ROBOT_STATE_STR(13)
 {
   // Debug messages
@@ -196,7 +197,7 @@ void DockDrive::velocityCommands(const double &vx_, const double &wz_) {
  *
  ****************************************************/
 void DockDrive::processBumpChargeEvent(const unsigned char& bumper, const unsigned char& charger) {
-  RobotDockingState::State new_state;
+  RobotDockingState::State new_state = RobotDockingState::UNKNOWN;
   if(charger && bumper) {
     new_state = RobotDockingState::BUMPED_DOCK;
     setStateVel(new_state, -0.01, 0.0);

--- a/kobuki_dock_drive/src/dock_drive_debug.cpp
+++ b/kobuki_dock_drive/src/dock_drive_debug.cpp
@@ -45,7 +45,7 @@ namespace kobuki {
 /***********************************************************
   @breif generates debug string to tell the current status of robot. Signal info + bumper + charger + current velocity + dock detector
  ***********************************************************/
-void DockDrive::generateDebugMessage(const std::vector<unsigned char>& signal_filt, const unsigned char &bumper, const unsigned char &charger, const ecl::LegacyPose2D<double>& pose_update, const std::string& debug_str)
+void DockDrive::generateDebugMessage(const std::vector<unsigned char>& signal_filt, const unsigned char &bumper, const unsigned char &charger, const ecl::LegacyPose2D<double>& /* pose_update */, const std::string& debug_str)
 {
 
   std::ostringstream debug_stream;

--- a/kobuki_dock_drive/src/dock_drive_states.cpp
+++ b/kobuki_dock_drive/src/dock_drive_states.cpp
@@ -76,9 +76,7 @@ namespace kobuki {
    *  @rotated       - indicates how much the robot has rotated while scan
    ********************************************************/
   void DockDrive::scan(RobotDockingState::State& nstate,double& nvx, double& nwz, const std::vector<unsigned char>& signal_filt, const ecl::LegacyPose2D<double>& pose_update, std::string& debug_str) {
-    unsigned char right = signal_filt[0];
     unsigned char mid   = signal_filt[1];
-    unsigned char left  = signal_filt[2];
 
     RobotDockingState::State next_state;
     double next_vx;
@@ -146,11 +144,10 @@ namespace kobuki {
    ********************************************************/
   void DockDrive::find_stream(RobotDockingState::State& nstate,double& nvx, double& nwz, const std::vector<unsigned char>& signal_filt) {
     unsigned char right = signal_filt[0];
-    unsigned char mid   = signal_filt[1];
     unsigned char left  = signal_filt[2];
-    RobotDockingState::State next_state;
-    double next_vx;
-    double next_wz;
+    RobotDockingState::State next_state = RobotDockingState::UNKNOWN;
+    double next_vx = 0.0;
+    double next_wz = 0.0;
 
     if(dock_detector > 0) // robot is located in right side of dock
     {
@@ -198,11 +195,10 @@ namespace kobuki {
   void DockDrive::get_stream(RobotDockingState::State& nstate,double& nvx, double& nwz, const std::vector<unsigned char>& signal_filt)
   {
     unsigned char right = signal_filt[0];
-    unsigned char mid   = signal_filt[1];
     unsigned char left  = signal_filt[2];
-    RobotDockingState::State next_state;
-    double next_vx;
-    double next_wz;
+    RobotDockingState::State next_state = RobotDockingState::UNKNOWN;
+    double next_vx = 0.0;
+    double next_wz = 0.0;
 
     if(dock_detector > 0) { // robot is located in right side of dock
       if (left & (DockStationIRState::FAR_LEFT + DockStationIRState::NEAR_LEFT)) {
@@ -249,9 +245,7 @@ namespace kobuki {
   ********************************************************/
   void DockDrive::aligned(RobotDockingState::State& nstate,double& nvx, double& nwz, const std::vector<unsigned char>& signal_filt, std::string& debug_str)
   {
-    unsigned char right = signal_filt[0];
     unsigned char mid   = signal_filt[1];
-    unsigned char left  = signal_filt[2];
     RobotDockingState::State next_state = nstate;
     double next_vx = nvx;
     double next_wz = nwz;

--- a/kobuki_driver/include/kobuki_driver/modules/acceleration_limiter.hpp
+++ b/kobuki_driver/include/kobuki_driver/modules/acceleration_limiter.hpp
@@ -55,7 +55,11 @@ public:
     last_timestamp(ecl::TimeStamp()),
     last_vx(0.0),
     last_wz(0.0)
-  {}
+  {
+    (void) last_speed;
+    (void) last_radius;
+  }
+
   void init(bool enable_acceleration_limiter
     , double linear_acceleration_max_= 0.5, double angular_acceleration_max_= 3.5
     , double linear_deceleration_max_=-0.5*1.2, double angular_deceleration_max_=-3.5*1.2)
@@ -122,6 +126,8 @@ public:
       ret_val.push_back(command_wz);
       return ret_val;
     }
+
+    return {};
   }
 
 private:

--- a/kobuki_driver/src/driver/CMakeLists.txt
+++ b/kobuki_driver/src/driver/CMakeLists.txt
@@ -8,7 +8,7 @@ file(GLOB SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
 # CONFIGURATIONS
 ##############################################################################
 
-set(VERSION_FILE ${PROJECT_SOURCE_DIR}/build/version_info.cpp)
+set(VERSION_FILE ${PROJECT_BINARY_DIR}/version_info.cpp)
 configure_file(version_info.cpp.in ${VERSION_FILE} @ONLY)
 
 ##############################################################################

--- a/kobuki_driver/src/driver/command.cpp
+++ b/kobuki_driver/src/driver/command.cpp
@@ -132,7 +132,7 @@ Command Command::SetExternalPower(const DigitalOutput &digital_output, Command::
   return outgoing;
 }
 
-Command Command::PlaySoundSequence(const enum SoundSequences &number, Command::Data &current_data)
+Command Command::PlaySoundSequence(const enum SoundSequences &number, Command::Data & /* current_data */)
 {
   uint16_t value; // gp_out is 16 bits
   value = number; // defined with the correct bit specification.

--- a/kobuki_driver/src/driver/diff_drive.cpp
+++ b/kobuki_driver/src/driver/diff_drive.cpp
@@ -30,13 +30,16 @@ DiffDrive::DiffDrive() :
   last_rad_left(0.0),
   last_rad_right(0.0),
 //  v(0.0), w(0.0), // command velocities, in [m/s] and [rad/s]
-  radius(0.0), speed(0.0), // command velocities, in [mm] and [mm/s]
   point_velocity(2,0.0), // command velocities, in [m/s] and [rad/s]
+  radius(0.0), // command velocities, in [mm] and [mm/s]
+  speed(0.0),
   bias(0.23), // wheelbase, wheel_to_wheel, in [m]
   wheel_radius(0.035), // radius of main wheel, in [m]
   tick_to_rad(0.002436916871363930187454f),
   diff_drive_kinematics(bias, wheel_radius)
-{}
+{
+  (void) imu_heading_offset;
+}
 
 /**
  * @brief Updates the odometry from firmware stamps and encoders.

--- a/kobuki_driver/src/driver/kobuki.cpp
+++ b/kobuki_driver/src/driver/kobuki.cpp
@@ -51,11 +51,11 @@ bool PacketFinder::checkSum()
 Kobuki::Kobuki() :
     shutdown_requested(false)
     , is_enabled(false)
+    , heading_offset(0.0/0.0)
     , is_connected(false)
     , is_alive(false)
     , version_info_reminder(0)
     , controller_info_reminder(0)
-    , heading_offset(0.0/0.0)
     , velocity_commands_debug(4, 0)
 {
 }

--- a/kobuki_driver/src/tools/simple_keyop.cpp
+++ b/kobuki_driver/src/tools/simple_keyop.cpp
@@ -197,7 +197,7 @@ void KobukiManager::spin()
     thread.cancel();
   }
 */
-  ecl::Sleep sleep(0.1);
+  ecl::Sleep sleep(ecl::Duration(0.1));
   while (!quit_requested){
     sleep();
   }

--- a/kobuki_ftdi/CMakeLists.txt
+++ b/kobuki_ftdi/CMakeLists.txt
@@ -4,8 +4,8 @@ find_package(catkin REQUIRED COMPONENTS ecl_command_line)
 
 # pkg-config packages
 find_package(PkgConfig)
-pkg_search_module(libusb REQUIRED libusb)
-pkg_search_module(libftdi REQUIRED libftdi)
+pkg_check_modules(libusb REQUIRED libusb)
+pkg_check_modules(libftdi REQUIRED libftdi)
 
 catkin_package(
    INCLUDE_DIRS include

--- a/kobuki_ftdi/include/kobuki_ftdi/scanner.hpp
+++ b/kobuki_ftdi/include/kobuki_ftdi/scanner.hpp
@@ -114,7 +114,7 @@ public:
     for (unsigned int i=0; i<devices.size(); i++) {
       struct usb_device *dev = devices[i];
       usb_dev_handle *h = usb_open(dev);
-      if ( h < 0 ) continue;
+      if ( h == NULL ) continue;
 
       std::map<std::string, std::string> M_desc;
       if ( usb_get_string_simple(h, dev->descriptor.iSerialNumber, buff, 128) < 0 ) continue;
@@ -216,7 +216,7 @@ public:
 
     struct usb_device *dev = devices[0];
     usb_dev_handle *h = usb_open(dev);
-    if( h < 0 ) {
+    if( h == NULL ) {
       return -1;
     }
     int ret_val = usb_reset(h);

--- a/kobuki_ftdi/include/kobuki_ftdi/writer.hpp
+++ b/kobuki_ftdi/include/kobuki_ftdi/writer.hpp
@@ -60,7 +60,9 @@ public:
     use_first_device(false),
     vendor_id(0x0403),
     product_id(0x6001)
-  {;}
+  {
+    (void) log_level;
+  }
 
   /**
    * reset flags to default state.

--- a/kobuki_ftdi/src/find_devices.cpp
+++ b/kobuki_ftdi/src/find_devices.cpp
@@ -15,7 +15,7 @@
 
 #include "kobuki_ftdi/scanner.hpp"
 
-int main(int argc, char** argv)
+int main(int /* argc */, char** /* argv */)
 {
   FTDI_Scanner scanner;
   int no_devices = scanner.scan();

--- a/kobuki_ftdi/src/ftdi_scan.cpp
+++ b/kobuki_ftdi/src/ftdi_scan.cpp
@@ -46,7 +46,7 @@
  ** Main
  *****************************************************************************/
 
-int main(int argc, char **argv)
+int main(int /* argc */, char ** /* argv */)
 {
 
   int ret, i, no_devices;

--- a/kobuki_ftdi/src/get_serial_number.cpp
+++ b/kobuki_ftdi/src/get_serial_number.cpp
@@ -12,7 +12,7 @@
 
 #include "kobuki_ftdi/scanner.hpp"
 
-int main(int argc, char** argv)
+int main(int /* argc */, char** /* argv */)
 {
   int ret_val;
   FTDI_Scanner scanner;

--- a/kobuki_ftdi/src/reset_device.cpp
+++ b/kobuki_ftdi/src/reset_device.cpp
@@ -10,7 +10,7 @@
 
 #include "kobuki_ftdi/scanner.hpp"
 
-int main(int argc, char** argv)
+int main(int /* argc */, char** /* argv */)
 {
   int ret_val;
   FTDI_Scanner scanner;


### PR DESCRIPTION
Backport of 67a7afe4ff0f822cf1b6726a298168065758e6c6 from https://github.com/yujinrobot/kobuki_core/pull/43 to branch `melodic` in order to fix many compiler warnings, and even errors when building with Clang 6 (the default Clang version on Ubuntu Bionic):

```cpp
kobuki_core/kobuki_ftdi/include/kobuki_ftdi/scanner.hpp:117:14: error: In file included from kobuki_core/kobuki_ftdi/src/flasher.cpp:15:                   
kobuki_core/kobuki_ftdi/src/../include/kobuki_ftdi/scanner.hppordered comparison between pointer and zero ('usb_dev_handle *' and 'int'):117                                                    
:14: error: ordered comparison between pointer and zero ('usb_dev_handle *' and 'int')                                                                                                                                               
      if ( h < 0 ) continue;                                                                                                                                                                                                         
           ~ ^ ~                                                                                                                                                                                                                     
      if ( h < 0 ) continue;                                                                                                                                                                                                         
           ~ ^ ~                                                                                                                                                                                                                     
kobuki_core/kobuki_ftdi/src/../include/kobuki_ftdi/scanner.hpp:219:11: error: ordered comparison between pointer and zero ('usb_dev_handle *' and 'int')                                        
    if( h < 0 ) {                                                                                                                                                                                                                    
        ~ ^ ~                                                                                                                                                                                                                        
kobuki_core/kobuki_ftdi/include/kobuki_ftdi/scanner.hpp:219:11: error: ordered comparison between pointer and zero ('usb_dev_handle *' and 'int')                                               
    if( h < 0 ) {                                                                                                                                                                                                                    
        ~ ^ ~                                                                                                                                                                                                                        
In file included from kobuki_core/kobuki_ftdi/src/find_devices.cpp:16:                                                                                                                          
kobuki_core/kobuki_ftdi/include/kobuki_ftdi/scanner.hpp:117:14: error: ordered comparison between pointer and zero ('usb_dev_handle *' and 'int')                                               
      if ( h < 0 ) continue;                                                                                                                                                                                                         
           ~ ^ ~                                                                                                                                                                                                                     
[ 45%] Linking CXX executable /opt/SBR-Whiz/devel/lib/kobuki_ftdi/ftdi_scan                                                                                                                                                          
kobuki_core/kobuki_ftdi/include/kobuki_ftdi/scanner.hpp:219:11: error: ordered comparison between pointer and zero ('usb_dev_handle *' and 'int')                                               
    if( h < 0 ) {                                                                                                                                                                                                                    
        ~ ^ ~                                                                                                                                                                                                                        
2 errors generated.                                                                                                                                                                                                                  
src/CMakeFiles/reset_device.dir/build.make:62: recipe for target 'src/CMakeFiles/reset_device.dir/reset_device.cpp.o' failed 
```

I also cherry-picked a patch from 72cb91c63d8f16bdcfe494ec4776f14030da7b82 (https://github.com/yujinrobot/kobuki_core/pull/37) to not generate `version_info.cpp` in the source-space.